### PR TITLE
chore: 脚手架工程增加 prepublishOnly 脚本

### DIFF
--- a/scaffolds/ice-algorithm-model-admin/package.json
+++ b/scaffolds/ice-algorithm-model-admin/package.json
@@ -19,6 +19,7 @@
   "scripts": {
     "start": "ice dev",
     "build": "ice build",
+    "prepublishOnly": "npm run build",
     "lint": "eslint . --ext '.js,.jsx' --fix"
   },
   "publishConfig": {

--- a/scaffolds/ice-application-management-admin/package.json
+++ b/scaffolds/ice-application-management-admin/package.json
@@ -45,6 +45,7 @@
   "scripts": {
     "start": "ice dev",
     "build": "ice build",
+    "prepublishOnly": "npm run build",
     "lint": "eslint . --ext '.js,.jsx' --fix"
   },
   "publishConfig": {

--- a/scaffolds/ice-asset-management-admin/package.json
+++ b/scaffolds/ice-asset-management-admin/package.json
@@ -46,6 +46,7 @@
   "scripts": {
     "start": "ice dev",
     "build": "ice build",
+    "prepublishOnly": "npm run build",
     "lint": "eslint . --ext '.js,.jsx' --fix"
   },
   "publishConfig": {

--- a/scaffolds/ice-build-platfrom/package.json
+++ b/scaffolds/ice-build-platfrom/package.json
@@ -19,6 +19,7 @@
   "scripts": {
     "start": "ice dev",
     "build": "ice build",
+    "prepublishOnly": "npm run build",
     "lint": "eslint . --ext '.js,.jsx' --fix"
   },
   "publishConfig": {

--- a/scaffolds/ice-commodity-management-admin/package.json
+++ b/scaffolds/ice-commodity-management-admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@icedesign/commodity-management-scaffold",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "该模板适用于商家类管理后台，布局方式采用左侧固定，右侧自适应方式，适合大量数据展示和界面操作",
   "author": "ice-admin@alibaba-inc.com",
   "homepage": "https://unpkg.com/@icedesign/commodity-management-scaffold@latest/build/index.html",
@@ -49,6 +49,7 @@
   "scripts": {
     "start": "ice dev",
     "build": "ice build",
+    "prepublishOnly": "npm run build",
     "lint": "eslint . --ext '.js,.jsx' --fix"
   },
   "buildConfig": {

--- a/scaffolds/ice-contract-management-admin/package.json
+++ b/scaffolds/ice-contract-management-admin/package.json
@@ -42,6 +42,7 @@
   "scripts": {
     "start": "ice dev",
     "build": "ice build",
+    "prepublishOnly": "npm run build",
     "lint": "eslint . --ext '.js,.jsx' --fix"
   },
   "publishConfig": {

--- a/scaffolds/ice-creator-admin/package.json
+++ b/scaffolds/ice-creator-admin/package.json
@@ -47,6 +47,7 @@
   "scripts": {
     "start": "ice dev",
     "build": "ice build",
+    "prepublishOnly": "npm run build",
     "lint": "eslint . --ext '.js,.jsx' --fix"
   },
   "buildConfig": {

--- a/scaffolds/ice-creator-landingpage/package.json
+++ b/scaffolds/ice-creator-landingpage/package.json
@@ -37,6 +37,7 @@
   "scripts": {
     "start": "ice dev",
     "build": "ice build",
+    "prepublishOnly": "npm run build",
     "lint": "eslint . --ext '.js,.jsx' --fix"
   },
   "publishConfig": {

--- a/scaffolds/ice-customer-analysis-admin/package.json
+++ b/scaffolds/ice-customer-analysis-admin/package.json
@@ -44,6 +44,7 @@
   "scripts": {
     "start": "ice dev",
     "build": "ice build",
+    "prepublishOnly": "npm run build",
     "lint": "eslint . --ext '.js,.jsx' --fix"
   },
   "publishConfig": {

--- a/scaffolds/ice-design-analysis/package.json
+++ b/scaffolds/ice-design-analysis/package.json
@@ -39,6 +39,7 @@
   "scripts": {
     "start": "ice dev",
     "build": "ice build",
+    "prepublishOnly": "npm run build",
     "lint": "eslint . --ext '.js,.jsx' --fix"
   },
   "publishConfig": {

--- a/scaffolds/ice-design-cms/package.json
+++ b/scaffolds/ice-design-cms/package.json
@@ -51,6 +51,7 @@
   "scripts": {
     "start": "ice dev",
     "build": "ice build",
+    "prepublishOnly": "npm run build",
     "lint": "eslint . --ext '.js,.jsx' --fix"
   },
   "publishConfig": {

--- a/scaffolds/ice-design-dashboard/package.json
+++ b/scaffolds/ice-design-dashboard/package.json
@@ -43,6 +43,7 @@
   "scripts": {
     "start": "ice dev",
     "build": "ice build",
+    "prepublishOnly": "npm run build",
     "lint": "eslint . --ext '.js,.jsx' --fix"
   },
   "publishConfig": {

--- a/scaffolds/ice-design-ecommerce/package.json
+++ b/scaffolds/ice-design-ecommerce/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@icedesign/ecommerce-scaffold",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "该模板适用于电商类管理后台，布局方式采用左侧固定，右侧自适应方式，适合大量数据展示和界面操作",
   "author": "ice-admin@alibaba-inc.com",
   "homepage": "https://unpkg.com/@icedesign/ecommerce-scaffold@latest/build/index.html",
@@ -48,6 +48,7 @@
   "scripts": {
     "start": "ice dev",
     "build": "ice build",
+    "prepublishOnly": "npm run build",
     "lint": "eslint . --ext '.js,.jsx' --fix"
   },
   "themeConfig": {

--- a/scaffolds/ice-design-iceworks/package.json
+++ b/scaffolds/ice-design-iceworks/package.json
@@ -16,6 +16,7 @@
   "scripts": {
     "start": "ice dev",
     "build": "ice build",
+    "prepublishOnly": "npm run build",
     "lint": "eslint . --ext '.js,.jsx' --fix"
   },
   "dependencies": {

--- a/scaffolds/ice-design-lite/package.json
+++ b/scaffolds/ice-design-lite/package.json
@@ -43,6 +43,7 @@
   "scripts": {
     "start": "ice dev",
     "build": "ice build",
+    "prepublishOnly": "npm run build",
     "lint": "eslint . --ext '.js,.jsx' --fix"
   },
   "publishConfig": {

--- a/scaffolds/ice-design-pro/package.json
+++ b/scaffolds/ice-design-pro/package.json
@@ -62,6 +62,7 @@
   "scripts": {
     "start": "ice dev",
     "build": "ice build",
+    "prepublishOnly": "npm run build",
     "lint": "eslint . --ext '.js,.jsx' --fix"
   },
   "publishConfig": {

--- a/scaffolds/ice-design-schools/package.json
+++ b/scaffolds/ice-design-schools/package.json
@@ -46,6 +46,7 @@
   "scripts": {
     "start": "ice dev",
     "build": "ice build",
+    "prepublishOnly": "npm run build",
     "lint": "eslint . --ext '.js,.jsx' --fix"
   },
   "publishConfig": {

--- a/scaffolds/ice-finance-dashboard/package.json
+++ b/scaffolds/ice-finance-dashboard/package.json
@@ -45,6 +45,7 @@
   "scripts": {
     "start": "ice dev",
     "build": "ice build",
+    "prepublishOnly": "npm run build",
     "lint": "eslint . --ext '.js,.jsx' --fix"
   },
   "publishConfig": {

--- a/scaffolds/ice-government-management-admin/package.json
+++ b/scaffolds/ice-government-management-admin/package.json
@@ -45,6 +45,7 @@
   "scripts": {
     "start": "ice dev",
     "build": "ice build",
+    "prepublishOnly": "npm run build",
     "lint": "eslint . --ext '.js,.jsx' --fix"
   },
   "publishConfig": {

--- a/scaffolds/ice-hr-management-admin/package.json
+++ b/scaffolds/ice-hr-management-admin/package.json
@@ -47,6 +47,7 @@
   "scripts": {
     "start": "ice dev",
     "build": "ice build",
+    "prepublishOnly": "npm run build",
     "lint": "eslint . --ext '.js,.jsx' --fix"
   },
   "publishConfig": {

--- a/scaffolds/ice-library-management-admin/package.json
+++ b/scaffolds/ice-library-management-admin/package.json
@@ -42,6 +42,7 @@
   "scripts": {
     "start": "ice dev",
     "build": "ice build",
+    "prepublishOnly": "npm run build",
     "lint": "eslint . --ext '.js,.jsx' --fix"
   },
   "publishConfig": {

--- a/scaffolds/ice-monitor-dashboard/package.json
+++ b/scaffolds/ice-monitor-dashboard/package.json
@@ -19,6 +19,7 @@
   "scripts": {
     "start": "ice dev",
     "build": "ice build",
+    "prepublishOnly": "npm run build",
     "lint": "eslint . --ext '.js,.jsx' --fix"
   },
   "publishConfig": {

--- a/scaffolds/ice-open-platform-landingpage/package.json
+++ b/scaffolds/ice-open-platform-landingpage/package.json
@@ -37,6 +37,7 @@
   "scripts": {
     "start": "ice dev",
     "build": "ice build",
+    "prepublishOnly": "npm run build",
     "lint": "eslint . --ext '.js,.jsx' --fix"
   },
   "publishConfig": {

--- a/scaffolds/ice-operation-admin/package.json
+++ b/scaffolds/ice-operation-admin/package.json
@@ -48,6 +48,7 @@
   "scripts": {
     "start": "ice dev",
     "build": "ice build",
+    "prepublishOnly": "npm run build",
     "lint": "eslint . --ext '.js,.jsx' --fix"
   },
   "buildConfig": {

--- a/scaffolds/ice-order-management-admin/package.json
+++ b/scaffolds/ice-order-management-admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@icedesign/order-management-scaffold",
-  "version": "2.0.6",
+  "version": "2.0.7",
   "description": "该模板适用于订单类管理后台，布局方式采用左侧固定，右侧自适应方式，适合大量数据展示和界面操作",
   "author": "ice-admin@alibaba-inc.com",
   "homepage": "https://unpkg.com/@icedesign/order-management-scaffold@latest/build/index.html",
@@ -49,6 +49,7 @@
   "scripts": {
     "start": "ice dev",
     "build": "ice build",
+    "prepublishOnly": "npm run build",
     "lint": "eslint . --ext '.js,.jsx' --fix"
   },
   "buildConfig": {

--- a/scaffolds/ice-project-management-admin/package.json
+++ b/scaffolds/ice-project-management-admin/package.json
@@ -49,6 +49,7 @@
   "scripts": {
     "start": "ice dev",
     "build": "ice build",
+    "prepublishOnly": "npm run build",
     "lint": "eslint . --ext '.js,.jsx' --fix"
   },
   "publishConfig": {

--- a/scaffolds/ice-reviews-management/package.json
+++ b/scaffolds/ice-reviews-management/package.json
@@ -48,6 +48,7 @@
   "scripts": {
     "start": "ice dev",
     "build": "ice build",
+    "prepublishOnly": "npm run build",
     "lint": "eslint . --ext '.js,.jsx' --fix"
   },
   "buildConfig": {

--- a/scaffolds/ice-scroll-screen-homepage/package.json
+++ b/scaffolds/ice-scroll-screen-homepage/package.json
@@ -19,6 +19,7 @@
   "scripts": {
     "start": "ice dev",
     "build": "ice build",
+    "prepublishOnly": "npm run build",
     "lint": "eslint . --ext '.js,.jsx' --fix"
   },
   "publishConfig": {

--- a/scaffolds/ice-task-management-admin/package.json
+++ b/scaffolds/ice-task-management-admin/package.json
@@ -48,6 +48,7 @@
   "scripts": {
     "start": "ice dev",
     "build": "ice build",
+    "prepublishOnly": "npm run build",
     "lint": "eslint . --ext '.js,.jsx' --fix"
   },
   "publishConfig": {

--- a/scaffolds/ice-typescript-starter/package.json
+++ b/scaffolds/ice-typescript-starter/package.json
@@ -38,6 +38,7 @@
   "scripts": {
     "start": "ice dev",
     "build": "ice build",
+    "prepublishOnly": "npm run build",
     "lint": "eslint . --ext '.js,.jsx' --fix"
   },
   "publishConfig": {

--- a/scaffolds/ice-universal-homepage/package.json
+++ b/scaffolds/ice-universal-homepage/package.json
@@ -42,6 +42,7 @@
   "scripts": {
     "start": "ice dev",
     "build": "ice build",
+    "prepublishOnly": "npm run build",
     "lint": "eslint . --ext '.js,.jsx' --fix"
   },
   "publishConfig": {

--- a/scaffolds/ice-usertrack-admin/package.json
+++ b/scaffolds/ice-usertrack-admin/package.json
@@ -44,6 +44,7 @@
   "scripts": {
     "start": "ice dev",
     "build": "ice build",
+    "prepublishOnly": "npm run build",
     "lint": "eslint . --ext '.js,.jsx' --fix"
   },
   "publishConfig": {

--- a/scaffolds/ice-voice-chat-admin/package.json
+++ b/scaffolds/ice-voice-chat-admin/package.json
@@ -44,6 +44,7 @@
   "scripts": {
     "start": "ice dev",
     "build": "ice build",
+    "prepublishOnly": "npm run build",
     "lint": "eslint . --ext '.js,.jsx' --fix"
   },
   "publishConfig": {

--- a/scaffolds/ice-website-homepage/package.json
+++ b/scaffolds/ice-website-homepage/package.json
@@ -16,6 +16,7 @@
   "scripts": {
     "start": "ice dev",
     "build": "ice build",
+    "prepublishOnly": "npm run build",
     "lint": "eslint . --ext '.js,.jsx' --fix"
   },
   "dependencies": {

--- a/scaffolds/ice-yunqi-homepage/package.json
+++ b/scaffolds/ice-yunqi-homepage/package.json
@@ -19,6 +19,7 @@
   "scripts": {
     "start": "ice dev",
     "build": "ice build",
+    "prepublishOnly": "npm run build",
     "lint": "eslint . --ext '.js,.jsx' --fix"
   },
   "publishConfig": {


### PR DESCRIPTION
scaffolds 项目工程 `package.json` 增加 `"prepublishOnly": "npm run build"` 脚本，其中这6个项目因为不是使用 ice 构建，所以没有增加 `prepublishOnly` 脚本。
- create-react-app
- ice-coreui-admin
- ice-creative-dashboard
- ice-light-bootstrap-dashboard
- ice-material-dashboard
- ice-opensource-site

下面三个项目的 `package.json` 同时修改了 version 字段，以便重新发包：
- ice-commodity-management-admin
- ice-design-ecommerce
- ice-order-management-admin

blocks 下有 272 个项目，均已确认有 `prepublishOnly` 脚本；
components 下有 17 个项目，均已确认有 `prepublishOnly` 脚本；
scaffolds 下有 41 个项目，其中 35 个已增加 `prepublishOnly` 脚本。