### PR TITLE
fix: StepForm direction keyword

### DIFF
--- a/blocks/StepForm/src/StepForm.jsx
+++ b/blocks/StepForm/src/StepForm.jsx
@@ -54,7 +54,7 @@ export default class StepForm extends Component {
             <Col xxs="24" s="5" l="5" style={styles.formLabel}>
               <Step
                 current={this.state.step}
-                direction="vertical"
+                direction="ver"
                 shape="dot"
                 animation={false}
                 style={styles.step}


### PR DESCRIPTION
Warning: Failed prop type: Invalid prop `direction` of value `vertical` supplied to `StepItem`, expected one of ["hoz","ver"]