### PR TITLE
fix: menu authority render error

### DIFF
--- a/scaffolds/ice-design-pro/package.json
+++ b/scaffolds/ice-design-pro/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@icedesign/pro-scaffold",
-  "version": "3.0.10",
+  "version": "3.0.11",
   "description": "该模板提供了路由、菜单、状态、权限、Mock、前后端通信、国际化等领域的完整方案，且内置了丰富的区块，主要用于展示现有区块的分类以及区块组合的效果，使用时需要根据需求进行删除和添加",
   "homepage": "https://unpkg.com/@icedesign/pro-scaffold@latest/build/index.html",
   "files": [

--- a/scaffolds/ice-design-pro/src/layouts/BasicLayout/components/Aside/index.jsx
+++ b/scaffolds/ice-design-pro/src/layouts/BasicLayout/components/Aside/index.jsx
@@ -25,20 +25,15 @@ function getLocaleKey(item) {
  * 根据权限决定是否渲染某个表单项
  * @param {object} item - 菜单项组件
  * @param {array} authorities - 菜单项允许权限数组
- * @param {string} key - 当前菜单项的 key
  * @return {object} 渲染的菜单项
  */
-function renderAuthItem(item, authorities, key) {
+function renderAuthItem(item, authorities) {
   if (authorities) {
-    return (
-      <Auth
-        authorities={authorities}
-        hidden
-        key={key}
-      >
-        {item}
-      </Auth>
-    );
+    return Auth({
+      children: item,
+      authorities,
+      hidden: true,
+    });
   } else {
     return item;
   }
@@ -65,7 +60,7 @@ function getSubMenuOrItem(item, index) {
         </SubNav>
       );
 
-      return renderAuthItem(subNav, item.authorities, index);
+      return renderAuthItem(subNav, item.authorities);
     }
     return null;
   }
@@ -77,7 +72,7 @@ function getSubMenuOrItem(item, index) {
     </NavItem>
   );
 
-  return renderAuthItem(navItem, item.authorities, index);
+  return renderAuthItem(navItem, item.authorities);
 }
 
 /**

--- a/scaffolds/ice-design-pro/src/layouts/BasicLayout/components/Header/index.jsx
+++ b/scaffolds/ice-design-pro/src/layouts/BasicLayout/components/Header/index.jsx
@@ -14,6 +14,24 @@ import Logo from '../Logo'
 
 import styles from './index.module.scss';
 
+/**
+ * 根据权限决定是否渲染某个表单项
+ * @param {object} item - 菜单项组件
+ * @param {array} authorities - 菜单项允许权限数组
+ * @return {object} 渲染的菜单项
+ */
+function renderAuthItem(item, authorities) {
+  if (authorities) {
+    return Auth({
+      children: item,
+      authorities,
+      hidden: true,
+    });
+  } else {
+    return item;
+  }
+}
+
 function Header(props) {
   const { request } = useRequest(userLogout);
   const userProfile = stores.useStore('userProfile');
@@ -93,19 +111,7 @@ function Header(props) {
                   </Nav.Item>
                 );
 
-                if (nav.authorities) {
-                  return (
-                    <Auth
-                      authorities={nav.authorities}
-                      hidden
-                      key={idx}
-                    >
-                      {item}
-                    </Auth>
-                  );
-                } else {
-                  return item;
-                }
+                return renderAuthItem(item, nav.authorities);
               })}
             </Nav>
           </div>


### PR DESCRIPTION
问题原因：当pro 模板中 menuConfig 配置 authorities 属性时，

```javascript
const asideMenuConfig = [
  {
    name: 'Dashboard',
    path: '/dashboard',
    icon: 'home2',
    authorities: ['admin'],
    children: [
      {
        name: 'monitor',
        path: '/dashboard/monitor',
      },
    ],
  },

```

且当前用户的登陆权限匹配到 authorities 中的权限时，由于原有权限方案是使用 Auth 组件包裹 SubMenu，而 Menu 组件的内部实现中使用了 cloneElement 将 Menu 的实例传入 SubMenu 中，包裹 Auth 导致 Menu 获取失败，因此报如下错误

![image](https://user-images.githubusercontent.com/5419233/65678108-53a36480-e085-11e9-8474-f01c7155fd10.png)

修复方法：将 Auth 组件当作纯函数使用，不引入额外的组件层级