### PR TITLE
Fix: electron scaffold can not debug

### DIFF
--- a/scaffolds/icejs-electron/package.json
+++ b/scaffolds/icejs-electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@icedesign/scaffold-electron",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "icejs Electron 模板，基于 vite",
   "main": "packages/main/build/index.cjs",
   "scripts": {

--- a/scaffolds/icejs-electron/packages/main/src/index.ts
+++ b/scaffolds/icejs-electron/packages/main/src/index.ts
@@ -8,8 +8,6 @@ async function createWindow() {
     show: false, // Use 'ready-to-show' event to show window
     webPreferences: {
       preload: join(__dirname, '../../preload/build/index.cjs'),
-      nodeIntegration: true,
-      contextIsolation: false,
     },
   });
 


### PR DESCRIPTION
在 electron 新版本中开启 `nodeIntegration` 后，无法正常渲染页面（表现是白屏），默认不要开启 `nodeIntegration: true`。`contextIsolation` 默认也不禁用
ref: https://www.electronjs.org/docs/latest/tutorial/security#2-do-not-enable-nodejs-integration-for-remote-content