### PR TITLE
fix: should call history after runtime setup

### DIFF
--- a/scaffolds/ice3-antd-pro/src/app.ts
+++ b/scaffolds/ice3-antd-pro/src/app.ts
@@ -8,6 +8,11 @@ export default defineAppConfig({});
 
 export const authConfig = defineAuthConfig(async (appData) => {
   const { userInfo = {} } = appData;
+  
+  if (userInfo.error) {
+    history?.push(`/login?redirect=${window.location.pathname}`);
+  }
+
   return {
     initialAuth: {
       admin: userInfo.userType === 'admin',
@@ -43,7 +48,8 @@ async function getUserInfo() {
     const userInfo = await fetchUserInfo();
     return userInfo;
   } catch (error) {
-    history?.push(`/login?redirect=${window.location.pathname}`);
+    return {
+      error
+    }
   }
-  return undefined;
 }

--- a/scaffolds/ice3-antd-pro/src/app.ts
+++ b/scaffolds/ice3-antd-pro/src/app.ts
@@ -8,7 +8,7 @@ export default defineAppConfig({});
 
 export const authConfig = defineAuthConfig(async (appData) => {
   const { userInfo = {} } = appData;
-  
+
   if (userInfo.error) {
     history?.push(`/login?redirect=${window.location.pathname}`);
   }
@@ -50,6 +50,6 @@ async function getUserInfo() {
   } catch (error) {
     return {
       error
-    }
+    };
   }
 }

--- a/scaffolds/ice3-antd-pro/src/app.ts
+++ b/scaffolds/ice3-antd-pro/src/app.ts
@@ -49,7 +49,7 @@ async function getUserInfo() {
     return userInfo;
   } catch (error) {
     return {
-      error
+      error,
     };
   }
 }


### PR DESCRIPTION
history 是在运行时才被赋值的，在 dataLoader 中调用 history 时，history 尚未被初始化，无法正常工作